### PR TITLE
Move preact to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "contributors": [
     "Louis DeScioli <louis.descioli@gmail.com>"
   ],
-  "dependencies": {
-    "preact": "^7.1.0"
+  "peerDependencies": {
+    "preact": ">=7.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",
@@ -44,6 +44,7 @@
     "enzyme": "^2.7.1",
     "jsdom": "^9.10.0",
     "mocha": "^3.2.0",
+    "preact": "^7.1.0",
     "preact-render-to-string": "^3.5.0",
     "rimraf": "^2.4.3"
   },


### PR DESCRIPTION
This gives control over the version of preact to the parent project which uses this project.

Otherwise, if the main project is using preact version 8+, then a bundle would contain both the preact 8+ from the main project and the preact 7.1.0 from this project.